### PR TITLE
修复有时会卡在无法推广的微博条目上

### DIFF
--- a/delWeibo.js
+++ b/delWeibo.js
@@ -51,7 +51,7 @@
                     if(window.location.href.indexOf('//weibo.com/u/') !== -1) { // 新
                         if($('i[title="更多"]')) {
                             $('i[title="更多"]').click();
-                            $All('.woo-pop-item-main')[6].click();
+                            $All('.woo-pop-item-main')[$All('.woo-pop-item-main').length-2].click();
                             $('.woo-dialog-ctrl').querySelectorAll('.woo-button-main')[1].click();
                             window.location.reload();
                         }


### PR DESCRIPTION
修复有时会卡在无法推广的微博条目上的bug。
原代码54行写的是点击位置6的菜单条目，但有时渣浪会不允许某条微博进行推广，于是下拉菜单会少一个“推广”条目，导致菜单按钮位置不正确。改成从下往上数第二个吧。